### PR TITLE
dropTake Funktion

### DIFF
--- a/07/aufgaben.hs
+++ b/07/aufgaben.hs
@@ -55,7 +55,8 @@ dropTake 0 [0,1,2,3,4,5,6] => []
 -}
 
 dropTake :: Int -> [a] -> [a]
-dropTake n xs = take n xs ++ drop (length xs - n) xs
+dropTake n [] = []
+dropTake n xs = if (length xs >= 2*n && n >= 0) then take n xs ++ drop (length xs - n) xs else xs
 
 {- Tests:
 > dropTake 1 [1,2,3,4,5,6,7,8,9]


### PR DESCRIPTION
Falls die Länge der Liste >= 2n ist muss die Ursprungsliste ausgegeben werden. Exhaustive Pattern Matching.